### PR TITLE
Use Assertions

### DIFF
--- a/src/main/java/notchatgpt/NotChatGPT.java
+++ b/src/main/java/notchatgpt/NotChatGPT.java
@@ -23,7 +23,12 @@ public class NotChatGPT {
 
     public String getResponse(String rawInput) {
 
-        String input = ui.readCommand(rawInput);
+        String input;
+        try {
+            input = ui.readCommand(rawInput);
+        } catch (AssertionError e) {
+            return ui.showError("Command cannot be empty");
+        }
         String output;
 
         if (Parser.isByeCommand(input)) {

--- a/src/main/java/notchatgpt/Ui.java
+++ b/src/main/java/notchatgpt/Ui.java
@@ -5,7 +5,10 @@ import java.util.Scanner;
 public class Ui {
     private Scanner sc = new Scanner(System.in);
 
-    public String readCommand(String s) {
+    public String readCommand(String s) throws AssertionError {
+        assert s != null : "Command cannot be null";
+        assert !s.trim().isEmpty() : "Command cannot be empty";
+
         return s.trim();
     }
 


### PR DESCRIPTION
Add input validation using assertions in readCommand method

This commit introduces input validation using Java's assert keyword in the readCommand method to ensure that the provided command is neither null nor empty.

* Added assertions to enforce input constraints:
* * assert s != null ensures that the input string is not null.
* * assert !s.trim().isEmpty() ensures that the input is not an empty string after trimming.
* Wrapped the readCommand invocation in a try-catch block to handle AssertionError.
* If an assertion fails, an error message "Command cannot be empty" is displayed.